### PR TITLE
Fix V2 uploads greater than 5GB

### DIFF
--- a/syncsketch/syncsketch.py
+++ b/syncsketch/syncsketch.py
@@ -138,6 +138,7 @@ class SyncSketchAPI:
         if self.debug:
             print("URL: %s, params: %s" % (url, params))
 
+        print(url)
         if postData or method == "post":
             r = requests.post(url, params=params, data=json.dumps(postData), headers=headers)
         elif patchData or method == "patch":
@@ -647,12 +648,13 @@ class SyncSketchAPI:
 
         # for media > 5gb use v1 upload api
         if content_length > 5 * 1000 * 1000:
-            return self.add_media_v1(
+            result = self.add_media_v1(
                 review_id=review_id,
                 filepath=filepath,
                 file_name=file_name,
                 noConvertFlag=noConvertFlag,
             )
+            return {"id": result["id"], "uuid": result["uuid"]}
 
 
         content_type = mimetypes.guess_type(filepath, strict=False)[0]

--- a/syncsketch/syncsketch.py
+++ b/syncsketch/syncsketch.py
@@ -138,7 +138,6 @@ class SyncSketchAPI:
         if self.debug:
             print("URL: %s, params: %s" % (url, params))
 
-        print(url)
         if postData or method == "post":
             r = requests.post(url, params=params, data=json.dumps(postData), headers=headers)
         elif patchData or method == "patch":

--- a/syncsketch/syncsketch.py
+++ b/syncsketch/syncsketch.py
@@ -670,14 +670,12 @@ class SyncSketchAPI:
             print("Failed to generate signed S3 url.\nAPI response:\n{}".format(url_response.text))
             return None
 
-        file = open(filepath, "rb")
-
         url_response_data = url_response.json()
         url = url_response_data["url"]
         fields = url_response_data["fields"]
-        files = {"file": file}
 
-        upload_response = requests.post(url, data=fields, files=files)
+        with open(filepath, "rb") as file:
+            upload_response = requests.post(url, data=fields, files={"file": file})
 
         if not upload_response.ok:
             print("Upload process failed while uploading file to S3.\nS3 response:\n{}".format(upload_response.text))


### PR DESCRIPTION
This is a temporary workaround until we move to multipart uploads. The V2 uploads will fall back to the V1 upload endpoint on uploads > 5GB.