### PR TITLE
optionally return user's connections in inactive/archived projects

### DIFF
--- a/syncsketch/syncsketch.py
+++ b/syncsketch/syncsketch.py
@@ -954,11 +954,20 @@ class SyncSketchAPI:
     def get_users_by_project_id(self, project_id):
         return self._get_json_response("/api/v2/all-project-users/{}/".format(project_id))
 
-    def get_connections_by_user_id(self, user_id, account_id):
+    def get_connections_by_user_id(self, user_id, account_id, include_inactive=None, include_archived=None):
         """
         Get all project and account connections for a user. Good for checking access for a user that might have left...
         """
-        return self._get_json_response("/api/v2/user/{}/connections/account/{}/".format(user_id, account_id))
+        get_params = {}
+        if include_inactive is not None:
+            get_params["include_inactive"] = "true" if include_inactive else "false"
+        if include_archived is not None:
+            get_params["include_archived"] = "true" if include_archived else "false"
+        return self._get_json_response("/api/v2/user/{}/connections/account/{}/{}".format(
+            user_id,
+            account_id,
+            "?{}".format(urlencode(get_params)) if get_params else "",
+        ))
 
     def get_user_by_id(self, userId):
         return self._get_json_response("/api/v1/simpleperson/%s/" % userId)

--- a/syncsketch/syncsketch.py
+++ b/syncsketch/syncsketch.py
@@ -958,16 +958,15 @@ class SyncSketchAPI:
         """
         Get all project and account connections for a user. Good for checking access for a user that might have left...
         """
-        get_params = {}
+        data = {}
         if include_inactive is not None:
-            get_params["include_inactive"] = "true" if include_inactive else "false"
+            data["include_inactive"] = "true" if include_inactive else "false"
         if include_archived is not None:
-            get_params["include_archived"] = "true" if include_archived else "false"
-        return self._get_json_response("/api/v2/user/{}/connections/account/{}/{}".format(
-            user_id,
-            account_id,
-            "?{}".format(urlencode(get_params)) if get_params else "",
-        ))
+            data["include_archived"] = "true" if include_archived else "false"
+        return self._get_json_response(
+            "/api/v2/user/{}/connections/account/{}/".format(user_id, account_id),
+            getData=data,
+        )
 
     def get_user_by_id(self, userId):
         return self._get_json_response("/api/v1/simpleperson/%s/" % userId)


### PR DESCRIPTION
Enhances the existing `get_connections_by_user_id` function to optionally get connections in inactive/archived projects.
```
from syncsketch import SyncSketchAPI

username = "username"
api_key = "api-key-123"

s = SyncSketchAPI(username, api_key)
account_id={{account ID}}
user_id={{user ID}}

# old - get user's connections in active projects
active_connections = s. get_connections_by_user_id(user_id, account_id)

# new! - get user's connections in active, inactive, and archived projects
all_connections = s. get_connections_by_user_id(user_id, account_id, include_inactive=True, include_archived=True)
```