### PR TITLE
Empty postData with Post call causes crash

### DIFF
--- a/syncsketch/syncsketch.py
+++ b/syncsketch/syncsketch.py
@@ -133,7 +133,7 @@ class SyncSketchAPI:
         method = method or "get"
         if postData or method == "post":
             method = "post"
-            r = requests.post(url, params=params, data=json.dumps(postData), headers=headers)
+            r = requests.post(url, params=params, data=json.dumps(postData) if postData else None, headers=headers)
         elif patchData or method == "patch":
             method = "patch"
             r = requests.patch(url, params=params, json=patchData, headers=headers)


### PR DESCRIPTION
In cases where the postData parameter was None and the method was post this would cause a crash:
`json.dumps(None) == "null"`
